### PR TITLE
BREAKING CHANGE: `AsyncAsk` now returns a future

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,12 +28,11 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Install Node Dependancies
+      - name: Install Node Dependencies
         run: |
           npm install @semantic-release/commit-analyzer \
           @semantic-release/release-notes-generator \
           @semantic-release/changelog \
-          @semantic-release/git \
           @semantic-release/github \
           @semantic-release/exec
 
@@ -43,6 +42,12 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: "Install cargo-llvm-cov"
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate summery code coverage
+        run: cargo llvm-cov report --summary-only --ignore-filename-regex "src/single/tuple.rs" --json --output-path lcov.info
+
       - name: Install Toml Edit
         run: cargo install toml-cli
 
@@ -51,7 +56,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: npx semantic-release
 # TODO(Alec): Upload test results to the release

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -39,26 +39,33 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: "Install cargo-llvm-cov"
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run unit tests
+        run: cargo test
+      # - name: "Install cargo-llvm-cov"
+      #   uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate line code coverage
-        run: cargo llvm-cov test --ignore-filename-regex "src/single/tuple.rs" --html
+      # - name: Generate line code coverage
+      #   run: cargo llvm-cov test --ignore-filename-regex "src/single/tuple.rs" --html
 
-      - name: Upload html test artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-html
-          path: target/llvm-cov/html/
+      # - name: Upload html test artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: test-html
+      #     path: target/llvm-cov/html/
 
-      - name: Generate summery code coverage
-        run: cargo llvm-cov report --summary-only --ignore-filename-regex "src/single/tuple.rs" --json --output-path lcov.info
+      # - name: Generate summery code coverage
+      #   run: cargo llvm-cov report --summary-only --ignore-filename-regex "src/single/tuple.rs" --json --output-path lcov.info
 
-      - name: Upload summery test artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.event.number }}-test-summery
-          path: lcov.info
+      # - name: Upload summery test artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: test-summery
+      #     path: lcov.info
+
+      # - name: Try and Download old line coverage
+      #   run: |
+      #     curl -s https://api.github.com/repos/wasmcompute/tokactor/releases/latest
+      #     | jq '.assets'
 
       # - name: Download master summery test artifact
       #   uses: actions/download-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 
 node_modules
+package*

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,14 +14,21 @@
       }
     ],
     [
-      "@semantic-release/git",
+      "@semantic-release/github",
       {
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
         "assets": [
-          "CHANGELOG.md"
+          {
+            "path": "CHANGELOG.md",
+            "label": "Change Log"
+          },
+          {
+            "path": "lcov.info",
+            "label": "Release Test Coverage"
+          }
         ]
       }
     ],
-    "@semantic-release/github",
     [
       "@semantic-release/exec",
       {

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -1,4 +1,6 @@
-use tokactor::{Actor, Ask, AsyncAsk, AsyncHandle, Ctx, Handler};
+use std::future::{ready, Ready};
+
+use tokactor::{Actor, Ask, AsyncAsk, Ctx, Handler};
 use tracing::Level;
 
 #[derive(Debug)]
@@ -28,11 +30,12 @@ impl Ask<Add> for Counter {
 }
 
 impl AsyncAsk<Add> for Counter {
-    type Result = ();
+    type Output = ();
+    type Future = Ready<Self::Output>;
 
-    fn handle(&mut self, message: Add, context: &mut Ctx<Self>) -> AsyncHandle<Self::Result> {
+    fn handle(&mut self, message: Add, _: &mut Ctx<Self>) -> Self::Future {
         self.inner += message.0;
-        context.anonymous_handle(async {})
+        ready(())
     }
 }
 

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -31,9 +31,9 @@ impl Ask<Add> for Counter {
 
 impl AsyncAsk<Add> for Counter {
     type Output = ();
-    type Future = Ready<Self::Output>;
+    type Future<'a> = Ready<Self::Output>;
 
-    fn handle(&mut self, message: Add, _: &mut Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, message: Add, _: &mut Ctx<Self>) -> Self::Future<'a> {
         self.inner += message.0;
         ready(())
     }

--- a/examples/http_world.rs
+++ b/examples/http_world.rs
@@ -17,19 +17,17 @@ impl Actor for Connection {}
 
 impl AsyncAsk<Request<()>> for Connection {
     type Output = ();
-    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+    type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-    fn handle(&mut self, req: Request<()>, context: &mut Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, req: Request<()>, _: &mut Ctx<Self>) -> Self::Future<'a> {
         println!("{:?}", req);
-        let address = context.address();
-        let writer = self.writer.clone();
+        let writer = &self.writer;
         Box::pin(async move {
             let str = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type:text/html\r\n\r\n<h1>{:?}</h1>",
                 req.headers().get("Host")
             );
             let _ = writer.write(str.into_bytes()).await;
-            let _ = address.await;
         })
     }
 }

--- a/examples/multi_tcp_world.rs
+++ b/examples/multi_tcp_world.rs
@@ -47,9 +47,9 @@ impl Actor for Connection {}
 
 impl AsyncAsk<Data> for Connection {
     type Output = ();
-    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+    type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-    fn handle(&mut self, Data(message): Data, _: &mut Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, Data(message): Data, _: &mut Ctx<Self>) -> Self::Future<'a> {
         let broadcaster = self.broadcaster.clone();
         Box::pin(async move {
             broadcaster.send_async(message).await.unwrap();

--- a/examples/multi_tcp_world.rs
+++ b/examples/multi_tcp_world.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future, pin::Pin};
 
 use tokactor::{
     util::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, ActorRef, Ask, AsyncAsk, AsyncHandle, Ctx, DeadActorResult, Handler, TcpRequest, World,
+    Actor, ActorRef, Ask, AsyncAsk, Ctx, DeadActorResult, Handler, TcpRequest, World,
 };
 use tracing::Level;
 
@@ -46,15 +46,12 @@ struct Connection {
 impl Actor for Connection {}
 
 impl AsyncAsk<Data> for Connection {
-    type Result = ();
+    type Output = ();
+    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
 
-    fn handle(
-        &mut self,
-        Data(message): Data,
-        context: &mut tokactor::Ctx<Self>,
-    ) -> AsyncHandle<()> {
+    fn handle(&mut self, Data(message): Data, _: &mut Ctx<Self>) -> Self::Future {
         let broadcaster = self.broadcaster.clone();
-        context.anonymous_handle(async move {
+        Box::pin(async move {
             broadcaster.send_async(message).await.unwrap();
         })
     }

--- a/examples/stateful_tcp_world.rs
+++ b/examples/stateful_tcp_world.rs
@@ -17,9 +17,9 @@ impl Actor for Connection {}
 
 impl AsyncAsk<Data> for Connection {
     type Output = ();
-    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+    type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-    fn handle(&mut self, Data(message): Data, _: &mut Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, Data(message): Data, _: &mut Ctx<Self>) -> Self::Future<'a> {
         let writer = self.write.clone();
         Box::pin(async move {
             let _ = writer.write(message).await;

--- a/examples/tcp_world.rs
+++ b/examples/tcp_world.rs
@@ -1,9 +1,11 @@
+use std::{future::Future, pin::Pin};
+
 use tokactor::{
     util::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, Ask, AsyncAsk, AsyncHandle, Ctx, TcpRequest, World,
+    Actor, Ask, AsyncAsk, Ctx, TcpRequest, World,
 };
 use tracing::Level;
 
@@ -13,11 +15,13 @@ struct Connection {
 impl Actor for Connection {}
 
 impl AsyncAsk<Data> for Connection {
-    type Result = ();
-    fn handle(&mut self, Data(msg): Data, context: &mut Ctx<Self>) -> AsyncHandle<Self::Result> {
+    type Output = ();
+    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+
+    fn handle(&mut self, Data(msg): Data, _: &mut Ctx<Self>) -> Self::Future {
         println!("{}", String::from_utf8(msg.clone()).unwrap());
         let writer = self.writer.clone();
-        context.anonymous_handle(async move {
+        Box::pin(async move {
             let _ = writer.write(msg).await;
         })
     }

--- a/examples/tcp_world.rs
+++ b/examples/tcp_world.rs
@@ -16,9 +16,9 @@ impl Actor for Connection {}
 
 impl AsyncAsk<Data> for Connection {
     type Output = ();
-    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+    type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-    fn handle(&mut self, Data(msg): Data, _: &mut Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, Data(msg): Data, _: &mut Ctx<Self>) -> Self::Future<'a> {
         println!("{}", String::from_utf8(msg.clone()).unwrap());
         let writer = self.writer.clone();
         Box::pin(async move {

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -6,4 +6,3 @@ version=$1
 
 toml set Cargo.toml package.version $version > output.toml 2>&1 
 mv output.toml Cargo.toml
-cargo build --release

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,6 +3,6 @@
 version=$1
 token=$CARGO_REGISTRY_TOKEN
 
-toml set Cargo.toml package.version $version > output.toml 2>&1 
-mv output.toml Cargo.toml
-cargo publish --allow-dirty --token $token
+# toml set Cargo.toml package.version $version > output.toml 2>&1 
+# mv output.toml Cargo.toml
+cargo publish --token $token

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -111,7 +111,7 @@ pub trait Ask<M: Message>: Actor {
 /// takes one messages and handles it.
 pub trait AsyncAsk<M: Message>: Actor {
     type Output: Message;
-    type Future: Future<Output = Self::Output> + Send + Sync;
+    type Future<'a>: Future<Output = Self::Output> + Send + Sync + 'a;
 
-    fn handle(&mut self, message: M, context: &mut Ctx<Self>) -> Self::Future;
+    fn handle<'a>(&'a mut self, message: M, context: &mut Ctx<Self>) -> Self::Future<'a>;
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,7 +1,6 @@
-use crate::{
-    context::{AsyncHandle, Ctx},
-    ActorRef, Message,
-};
+use std::future::Future;
+
+use crate::{context::Ctx, ActorRef, Message};
 
 pub enum Scheduler {
     Blocking,
@@ -111,7 +110,8 @@ pub trait Ask<M: Message>: Actor {
 /// be some type of async operation and thus is executed by a anonymous actor that
 /// takes one messages and handles it.
 pub trait AsyncAsk<M: Message>: Actor {
-    type Result: Message;
+    type Output: Message;
+    type Future: Future<Output = Self::Output> + Send + Sync;
 
-    fn handle(&mut self, message: M, context: &mut Ctx<Self>) -> AsyncHandle<Self::Result>;
+    fn handle(&mut self, message: M, context: &mut Ctx<Self>) -> Self::Future;
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -267,7 +267,7 @@ where
     /// fail during delivery of the message or getting a response. If the message
     /// fails at any point, this method will return None. Otherwise, on successful
     /// operation, it returns the responding value.
-    pub async fn try_async_ask<M>(&self, message: M) -> Option<A::Result>
+    pub async fn try_async_ask<M>(&self, message: M) -> Option<A::Output>
     where
         M: Message,
         A: Actor + AsyncAsk<M>,
@@ -288,7 +288,7 @@ where
     /// back to the caller. Otherwise, if the other actor drops after the message
     /// has been recieved, we return an error without the original message as it
     /// has been lost.
-    pub async fn async_ask<M>(&self, message: M) -> Result<A::Result, AskError<M>>
+    pub async fn async_ask<M>(&self, message: M) -> Result<A::Output, AskError<M>>
     where
         M: Message,
         A: Actor + AsyncAsk<M>,

--- a/src/anonymous.rs
+++ b/src/anonymous.rs
@@ -67,13 +67,13 @@ impl<In, Out, Fut, F> AsyncAsk<In> for AnonymousActor<In, Fut, F>
 where
     In: Message,
     Out: Message,
-    Fut: Message + Future<Output = Out>,
     F: Fn(In) -> Fut + Send + Sync + 'static,
+    for<'a> Fut: Future<Output = Out> + Send + Sync + 'a,
 {
     type Output = Out;
-    type Future = Fut;
+    type Future<'a> = Fut;
 
-    fn handle(&mut self, message: In, _: &mut Ctx<Self>) -> Fut {
+    fn handle<'a>(&'a mut self, message: In, _: &mut Ctx<Self>) -> Self::Future<'a> {
         let f = self.f.take().unwrap();
         (f)(message)
     }

--- a/src/anonymous.rs
+++ b/src/anonymous.rs
@@ -70,11 +70,12 @@ where
     Fut: Message + Future<Output = Out>,
     F: Fn(In) -> Fut + Send + Sync + 'static,
 {
-    type Result = Out;
+    type Output = Out;
+    type Future = Fut;
 
-    fn handle(&mut self, message: In, ctx: &mut Ctx<Self>) -> crate::AsyncHandle<Self::Result> {
+    fn handle(&mut self, message: In, _: &mut Ctx<Self>) -> Fut {
         let f = self.f.take().unwrap();
-        ctx.anonymous_handle(async move { (f)(message).await })
+        (f)(message)
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -329,7 +329,7 @@ impl<A: Actor> Executor<A> {
                     schedule = "non-blocking",
                     "recieved message"
                 );
-                message.send(&mut self.actor, &mut self.context)
+                message.send(&mut self.actor, &mut self.context).await;
             }
         }
         tracing::trace!(

--- a/src/io/fs.rs
+++ b/src/io/fs.rs
@@ -1,0 +1,1 @@
+pub struct FsActor {}

--- a/src/single/context.rs
+++ b/src/single/context.rs
@@ -58,10 +58,10 @@ impl<A: Actor, B: Tuple> CtxBuilder<A, B> {
 
     pub fn ask_asyncer<In: Message>(
         self,
-    ) -> CtxBuilder<A, (ActorAsyncAskRef<In, <A as AsyncAsk<In>>::Result>, B)>
+    ) -> CtxBuilder<A, (ActorAsyncAskRef<In, <A as AsyncAsk<In>>::Output>, B)>
     where
         A: AsyncAsk<In>,
-        (ActorAsyncAskRef<In, <A as AsyncAsk<In>>::Result>, B): Tuple,
+        (ActorAsyncAskRef<In, <A as AsyncAsk<In>>::Output>, B): Tuple,
     {
         let (tx, rx) = mpsc::channel(A::mailbox_size());
         let sender = ActorAsyncAskRef::new(tx);

--- a/src/single/mod.rs
+++ b/src/single/mod.rs
@@ -18,12 +18,14 @@ pub type AskRx<In, A> = mpsc::Receiver<(
 
 pub type AsyncAskRx<In, A> = mpsc::Receiver<(
     In,
-    oneshot::Sender<Result<<A as AsyncAsk<In>>::Result, AskError<In>>>,
+    oneshot::Sender<Result<<A as AsyncAsk<In>>::Output, AskError<In>>>,
 )>;
 
 #[cfg(test)]
 mod tests {
-    use crate::{Actor, Ask, AsyncAsk, AsyncHandle, Ctx, Handler};
+    use std::{future::Future, pin::Pin};
+
+    use crate::{Actor, Ask, AsyncAsk, Ctx, Handler};
 
     use super::context::CtxBuilder;
 
@@ -57,10 +59,12 @@ mod tests {
     }
 
     impl<A: SafeMsg, B: SafeMsg, C: SafeMsg> AsyncAsk<MsgC<C>> for Test<A, B, C> {
-        type Result = ();
+        type Output = ();
+        type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
 
-        fn handle(&mut self, _: MsgC<C>, ctx: &mut Ctx<Self>) -> AsyncHandle<Self::Result> {
-            ctx.anonymous_handle(async move {})
+        fn handle(&mut self, _: MsgC<C>, _: &mut Ctx<Self>) -> Self::Future {
+            #[allow(clippy::unused_unit)]
+            Box::pin(async move { () })
         }
     }
 

--- a/src/single/mod.rs
+++ b/src/single/mod.rs
@@ -60,9 +60,9 @@ mod tests {
 
     impl<A: SafeMsg, B: SafeMsg, C: SafeMsg> AsyncAsk<MsgC<C>> for Test<A, B, C> {
         type Output = ();
-        type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+        type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-        fn handle(&mut self, _: MsgC<C>, _: &mut Ctx<Self>) -> Self::Future {
+        fn handle<'a>(&'a mut self, _: MsgC<C>, _: &mut Ctx<Self>) -> Self::Future<'a> {
             #[allow(clippy::unused_unit)]
             Box::pin(async move { () })
         }

--- a/src/utils/router.rs
+++ b/src/utils/router.rs
@@ -85,9 +85,9 @@ where
     A: Actor + Default + AsyncAsk<M>,
 {
     type Output = A::Output;
-    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+    type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-    fn handle(&mut self, message: M, _: &mut crate::Ctx<Self>) -> Self::Future {
+    fn handle<'a>(&'a mut self, message: M, _: &mut crate::Ctx<Self>) -> Self::Future<'a> {
         match &mut self.strategy {
             RouterStrategy::RoundRobin { index } => {
                 let max_retry = self.max_retry;
@@ -173,9 +173,9 @@ mod tests {
 
     impl AsyncAsk<Id> for ChoosenActor {
         type Output = ChoosenActor;
-        type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
+        type Future<'a> = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'a>>;
 
-        fn handle(&mut self, _: Id, _: &mut crate::Ctx<Self>) -> Self::Future {
+        fn handle<'a>(&'a mut self, _: Id, _: &mut crate::Ctx<Self>) -> Self::Future<'a> {
             let number = self.number;
             Box::pin(async move { ChoosenActor { number } })
         }

--- a/src/utils/router.rs
+++ b/src/utils/router.rs
@@ -1,3 +1,5 @@
+use std::{future::Future, pin::Pin};
+
 use crate::{Actor, ActorContext, ActorRef, AskError, AsyncAsk, DeadActorResult, Handler, Message};
 
 pub enum RouterStrategyBuilder {
@@ -82,13 +84,10 @@ where
     M: Message,
     A: Actor + Default + AsyncAsk<M>,
 {
-    type Result = A::Result;
+    type Output = A::Output;
+    type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
 
-    fn handle(
-        &mut self,
-        message: M,
-        context: &mut crate::Ctx<Self>,
-    ) -> crate::AsyncHandle<Self::Result> {
+    fn handle(&mut self, message: M, _: &mut crate::Ctx<Self>) -> Self::Future {
         match &mut self.strategy {
             RouterStrategy::RoundRobin { index } => {
                 let max_retry = self.max_retry;
@@ -96,7 +95,7 @@ where
 
                 let address = self.actors[actor_index].clone();
                 *index = (*index + 1) % self.max_actors;
-                context.anonymous_handle(async move {
+                Box::pin(async move {
                     match address.async_ask(message).await {
                         Ok(result) => result,
                         Err(AskError::Closed(msg)) if max_retry > 0 => {
@@ -146,6 +145,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{future::Future, pin::Pin};
+
     use crate::{Actor, AsyncAsk};
 
     use super::{Router, RouterBuilder};
@@ -171,11 +172,12 @@ mod tests {
     }
 
     impl AsyncAsk<Id> for ChoosenActor {
-        type Result = ChoosenActor;
+        type Output = ChoosenActor;
+        type Future = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync>>;
 
-        fn handle(&mut self, _: Id, c: &mut crate::Ctx<Self>) -> crate::AsyncHandle<Self::Result> {
+        fn handle(&mut self, _: Id, _: &mut crate::Ctx<Self>) -> Self::Future {
             let number = self.number;
-            c.anonymous_handle(async move { ChoosenActor { number } })
+            Box::pin(async move { ChoosenActor { number } })
         }
     }
 


### PR DESCRIPTION
Proving more control to the user to allow actors to execute async functions. This allows for the user to have more control over how they return futures and allows them to program their own.

WIP: Because we know that the user can only possibly be processing one value at a time, even in an async function, we should be able to provide them access to references of the source object. Still trying to figure this out.