### PR TITLE
feat: Changed `Ask` signature. Require the return type to `AskResult::Reply` or `AskResult::Task`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokactor"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Alec Di Vito"]
 description = "A actor model framework wrapped around tokio"
 documentation = "https://docs.rs/tokactor"
@@ -19,12 +19,20 @@ name = "tokactor"
 path = "src/lib.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "signal", "net", "io-util", "macros"]}
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "signal",
+    "net",
+    "io-util",
+    "macros",
+] }
 tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-criterion = { version = "0.5", features = ["html_reports", "async_tokio"]}
+criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 httparse = "1.8.0"
 http = "0.2.9"
 tracing-subscriber = "0.3"

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -1,10 +1,16 @@
-use std::future::{ready, Ready};
+use std::{
+    future::{ready, Ready},
+    time::Duration,
+};
 
-use tokactor::{Actor, Ask, AsyncAsk, Ctx, Handler};
+use tokactor::{Actor, Ask, AskResult, AsyncAsk, Ctx, Handler};
 use tracing::Level;
 
 #[derive(Debug)]
 struct Add(u32);
+
+#[derive(Debug)]
+struct Sleep(u64);
 
 #[derive(Debug)]
 struct Sum;
@@ -24,8 +30,20 @@ impl Handler<Add> for Counter {
 
 impl Ask<Add> for Counter {
     type Result = ();
-    fn handle(&mut self, message: Add, _: &mut Ctx<Self>) -> Self::Result {
+    fn handle(&mut self, message: Add, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
         self.inner += message.0;
+        AskResult::Reply(())
+    }
+}
+
+impl Ask<Sleep> for Counter {
+    type Result = ();
+    fn handle(&mut self, Sleep(time): Sleep, context: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        let duration = Duration::from_secs(time);
+        let handle = context.anonymous_handle(async move {
+            tokio::time::sleep(duration).await;
+        });
+        AskResult::Task(handle)
     }
 }
 
@@ -42,8 +60,8 @@ impl AsyncAsk<Add> for Counter {
 impl Ask<Sum> for Counter {
     type Result = Counter;
 
-    fn handle(&mut self, _: Sum, _: &mut Ctx<Self>) -> Self::Result {
-        Counter { inner: self.inner }
+    fn handle(&mut self, _: Sum, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        AskResult::Reply(Counter { inner: self.inner })
     }
 }
 
@@ -66,4 +84,7 @@ async fn main() {
     addr.async_ask(Add(10)).await.unwrap();
     let counter = addr.ask(Sum).await.unwrap();
     println!("Total count should be 30 = {:?}", counter);
+    println!("Sleeping for 3 seconds");
+    addr.ask(Sleep(3)).await.unwrap();
+    println!("Complete");
 }

--- a/examples/http_world.rs
+++ b/examples/http_world.rs
@@ -6,7 +6,7 @@ use tokactor::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, Ask, AsyncAsk, Ctx, TcpRequest, World,
+    Actor, Ask, AskResult, AsyncAsk, Ctx, TcpRequest, World,
 };
 use tracing::Level;
 
@@ -66,8 +66,8 @@ impl Actor for Router {}
 impl Ask<TcpRequest> for Router {
     type Result = Connection;
 
-    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> Self::Result {
-        Connection { writer: message.0 }
+    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        AskResult::Reply(Connection { writer: message.0 })
     }
 }
 

--- a/examples/multi_tcp_world.rs
+++ b/examples/multi_tcp_world.rs
@@ -5,7 +5,7 @@ use tokactor::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, ActorRef, Ask, AsyncAsk, Ctx, DeadActorResult, Handler, TcpRequest, World,
+    Actor, ActorRef, Ask, AskResult, AsyncAsk, Ctx, DeadActorResult, Handler, TcpRequest, World,
 };
 use tracing::Level;
 
@@ -73,7 +73,7 @@ impl Actor for Router {
 impl Ask<TcpRequest> for Router {
     type Result = Connection;
 
-    fn handle(&mut self, message: TcpRequest, context: &mut Ctx<Self>) -> Self::Result {
+    fn handle(&mut self, message: TcpRequest, context: &mut Ctx<Self>) -> AskResult<Self::Result> {
         let conn = Connection {
             id: self.counter,
             broadcaster: self.broadcaster.as_ref().unwrap().clone(),
@@ -86,7 +86,7 @@ impl Ask<TcpRequest> for Router {
         });
 
         self.counter += 1;
-        conn
+        AskResult::Reply(conn)
     }
 }
 

--- a/examples/ping-pong.rs
+++ b/examples/ping-pong.rs
@@ -1,4 +1,4 @@
-use tokactor::{Actor, Ask, Ctx};
+use tokactor::{Actor, Ask, AskResult, Ctx};
 use tracing::Level;
 
 /// [PingPong] is a basic actor that will print
@@ -39,10 +39,10 @@ impl Ask<Msg> for PingPong {
     type Result = Msg;
 
     // This is our main message handler
-    fn handle(&mut self, message: Msg, _: &mut Ctx<Self>) -> Self::Result {
+    fn handle(&mut self, message: Msg, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
         message.print();
         self.counter += 1;
-        message.next()
+        AskResult::Reply(message.next())
     }
 }
 

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use tokactor::{Actor, ActorRef, Ask, Ctx, Handler};
+use tokactor::{Actor, ActorRef, Ask, AskResult, Ctx, Handler};
 use tracing::Level;
 
 #[derive(Default)]
@@ -10,8 +10,8 @@ impl Actor for PingReceiver {}
 impl Ask<Ping> for PingReceiver {
     type Result = Str;
 
-    fn handle(&mut self, _msg: Ping, _ctx: &mut Ctx<Self>) -> Self::Result {
-        Str("Pong".to_string())
+    fn handle(&mut self, _msg: Ping, _ctx: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        AskResult::Reply(Str("Pong".to_string()))
     }
 }
 
@@ -65,7 +65,7 @@ async fn main() {
 
     tracing::info!("Starting up...");
 
-    let ping_rx = PingReceiver::default().start();
+    let ping_rx = PingReceiver.start();
     let ping_tx = PingSender { peer: ping_rx }.start();
 
     tokio::time::sleep(Duration::from_secs(10)).await;

--- a/examples/stateful_tcp_world.rs
+++ b/examples/stateful_tcp_world.rs
@@ -5,7 +5,8 @@ use tokactor::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, ActorContext, Ask, AsyncAsk, Ctx, DeadActorResult, Handler, TcpRequest, World,
+    Actor, ActorContext, Ask, AskResult, AsyncAsk, Ctx, DeadActorResult, Handler, TcpRequest,
+    World,
 };
 use tracing::Level;
 
@@ -40,11 +41,11 @@ impl Actor for Router {}
 impl Ask<TcpRequest> for Router {
     type Result = Connection;
 
-    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> Self::Result {
-        Connection {
+    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        AskResult::Reply(Connection {
             write: message.0,
             _state: self.state.clone(),
-        }
+        })
     }
 }
 

--- a/examples/tcp_world.rs
+++ b/examples/tcp_world.rs
@@ -5,7 +5,7 @@ use tokactor::{
         io::{DataFrameReceiver, Writer},
         read::Read,
     },
-    Actor, Ask, AsyncAsk, Ctx, TcpRequest, World,
+    Actor, Ask, AskResult, AsyncAsk, Ctx, TcpRequest, World,
 };
 use tracing::Level;
 
@@ -44,8 +44,8 @@ impl Actor for Router {}
 impl Ask<TcpRequest> for Router {
     type Result = Connection;
 
-    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> Self::Result {
-        Connection { writer: message.0 }
+    fn handle(&mut self, message: TcpRequest, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
+        AskResult::Reply(Connection { writer: message.0 })
     }
 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crate::{context::Ctx, ActorRef, Message};
+use crate::{context::Ctx, message::AskResult, ActorRef, Message};
 
 pub enum Scheduler {
     Blocking,
@@ -103,7 +103,7 @@ pub trait Handler<M: Message>: Actor {
 pub trait Ask<M: Message>: Actor {
     type Result: Message;
 
-    fn handle(&mut self, message: M, context: &mut Ctx<Self>) -> Self::Result;
+    fn handle(&mut self, message: M, context: &mut Ctx<Self>) -> AskResult<Self::Result>;
 
     /// Explain the type of scheduler the actor should use
     fn scheduler() -> Scheduler {

--- a/src/anonymous.rs
+++ b/src/anonymous.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, marker::PhantomData};
 
-use crate::{Actor, Ask, AsyncAsk, Ctx, Handler, Message};
+use crate::{Actor, Ask, AskResult, AsyncAsk, Ctx, Handler, Message};
 
 pub struct AnonymousActor<In: Message, Out: Message, F: Fn(In) -> Out> {
     f: Option<F>,
@@ -57,9 +57,9 @@ where
 {
     type Result = Out;
 
-    fn handle(&mut self, message: In, _: &mut Ctx<Self>) -> Self::Result {
+    fn handle(&mut self, message: In, _: &mut Ctx<Self>) -> AskResult<Out> {
         let f = self.f.take().unwrap();
-        (f)(message)
+        AskResult::Reply((f)(message))
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
     envelope::SendMessage,
     message::DeadActor,
     single::{AskRx, AsyncAskRx},
-    Actor, ActorRef, Ask, AsyncAsk, Ctx, Handler, Message, Scheduler, SendError,
+    Actor, ActorRef, Ask, AskResult, AsyncAsk, Ctx, Handler, Message, Scheduler, SendError,
 };
 
 pub(crate) enum ExecutorLoop {
@@ -94,7 +94,10 @@ impl<A: Actor> RawExecutor<A> {
         A: Ask<M>,
     {
         if let Some(executor) = self.0.as_mut() {
-            executor.actor.handle(message, &mut executor.context)
+            match executor.actor.handle(message, &mut executor.context) {
+                AskResult::Reply(reply) => reply,
+                AskResult::Task(_) => unreachable!(), // TODO(Alec): need to fix this
+            }
         } else {
             unreachable!()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod world;
 pub use crate::actor::{Actor, Ask, AsyncAsk, Handler, Scheduler};
 pub use crate::address::{ActorRef, AnonymousRef, AskError, IntoFutureError, SendError};
 pub use crate::context::{ActorContext, Ctx};
-pub use crate::message::{DeadActorResult, Message};
+pub use crate::message::{AskResult, DeadActorResult, Message};
 pub use crate::world::{builder::WorldBuilder, messages::TcpRequest, World, WorldResult};
 
 pub mod util {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,16 @@
-use tokio::{sync::oneshot, task::JoinError};
+use tokio::{
+    sync::oneshot,
+    task::{JoinError, JoinHandle},
+};
 
-use crate::{Actor, Ctx};
+use crate::{context::AnonymousActor, Actor, Ctx};
+
+pub struct AsyncHandle<T: Message>(pub(crate) JoinHandle<AnonymousActor<T>>);
+
+pub enum AskResult<T: Message> {
+    Reply(T),
+    Task(AsyncHandle<T>),
+}
 
 /// The message that an actor can handle.
 pub trait Message: Send + Sync + 'static {}

--- a/src/single/mod.rs
+++ b/src/single/mod.rs
@@ -25,7 +25,7 @@ pub type AsyncAskRx<In, A> = mpsc::Receiver<(
 mod tests {
     use std::{future::Future, pin::Pin};
 
-    use crate::{Actor, Ask, AsyncAsk, Ctx, Handler};
+    use crate::{Actor, Ask, AskResult, AsyncAsk, Ctx, Handler};
 
     use super::context::CtxBuilder;
 
@@ -55,7 +55,9 @@ mod tests {
 
     impl<A: SafeMsg, B: SafeMsg, C: SafeMsg> Ask<MsgB<B>> for Test<A, B, C> {
         type Result = ();
-        fn handle(&mut self, _: MsgB<B>, _: &mut Ctx<Self>) -> Self::Result {}
+        fn handle(&mut self, _: MsgB<B>, _: &mut Ctx<Self>) -> AskResult<Self::Result> {
+            AskResult::Reply(())
+        }
     }
 
     impl<A: SafeMsg, B: SafeMsg, C: SafeMsg> AsyncAsk<MsgC<C>> for Test<A, B, C> {

--- a/src/utils/workflow/mod.rs
+++ b/src/utils/workflow/mod.rs
@@ -98,7 +98,7 @@ where
 #[cfg(test)]
 mod tests {
 
-    use crate::{Actor, Ask};
+    use crate::{Actor, Ask, AskResult};
 
     use super::{Workflow, WorkflowBase};
 
@@ -129,14 +129,14 @@ mod tests {
     impl Ask<Number> for AddOnce {
         type Result = Number;
 
-        fn handle(&mut self, message: Number, _: &mut crate::Ctx<Self>) -> Self::Result {
-            match message {
+        fn handle(&mut self, message: Number, _: &mut crate::Ctx<Self>) -> AskResult<Self::Result> {
+            AskResult::Reply(match message {
                 Number::I32(i32) => Number::I64(i32 as i64),
                 Number::I64(i64) => Number::I128(i64 as i128),
                 Number::I128(i128) => Number::U32(i128 as u32),
                 Number::U32(u32) => Number::U64(u32 as u64),
                 Number::U64(u64) => Number::I32(u64 as i32),
-            }
+            })
         }
     }
 


### PR DESCRIPTION
I still need there to be a way to pass tasks that are **not** Sync. This task used to be fulfilled by `AsyncAsk` however we found a way to convert that to a Future so it stops the actor for some amount of time, which, sadly, at times is wanted.

However, for actors that need to move fast they can now depend on `.send` and `.ask`, with `.ask` guaranteeing a response if a task returns a future or just a reply.

More work is needed to create a better interface, but for the time being I don't have the time to figure that out.

This closes #19 and the issue #22 has been introduce to fix the problem that this PR produces